### PR TITLE
Smoothen out the reported current

### DIFF
--- a/TeensyModules/V4.1/Firmware/Autosteer_gps_teensy_v4_1/KeyaCANBUS.ino
+++ b/TeensyModules/V4.1/Firmware/Autosteer_gps_teensy_v4_1/KeyaCANBUS.ino
@@ -182,11 +182,11 @@ void KeyaBus_Receive() {
 			//KeyaCurrentSensorReading = abs(KeyaBusReceiveData.buf[4]) * 20;
 
 			if (KeyaBusReceiveData.buf[4] == 0xFF) {
-				KeyaCurrentSensorReading = (256 - KeyaBusReceiveData.buf[5]) * 20;
+				KeyaCurrentSensorReading =  (0.9 * KeyaCurrentSensorReading  ) + ( 0.1 * (256 - KeyaBusReceiveData.buf[5]) * 20);
 				Serial.println("Current reading: " + String(KeyaCurrentSensorReading));
 			}
 			else {
-				KeyaCurrentSensorReading = KeyaBusReceiveData.buf[5];
+				KeyaCurrentSensorReading = (0.9 * KeyaCurrentSensorReading  ) + ( 0.1 * KeyaBusReceiveData.buf[5] );
 			}
 
 			//if (debugKeya) Serial.println("Heartbeat current is " + String(KeyaCurrentSensorReading));


### PR DESCRIPTION
By smoothening the reported current we can avoid the disengage when the wheel is engaged. When we're way off the line it often starts with maxPWM which draws a ton of current. This code approach allows that initial spike to be flattened. This way the disengage % could be set to much lower.